### PR TITLE
Adding CocoaPods Podspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# OS X
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must ends with two \r.
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+# Xcode
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+profile
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa

--- a/BeaconOSX.podspec
+++ b/BeaconOSX.podspec
@@ -1,0 +1,41 @@
+Pod::Spec.new do |s|
+  s.name         = "BeaconOSX"
+  s.version      = "0.0.1"
+  s.summary      = "Use a Bluetooth 4 enabled Mac running Mavericks as an iBeacon."
+  s.description  = <<-DESC
+                   A longer description of BeaconOSX in Markdown format.
+
+                   * Think: Why did you write this? What is the focus? What does it do?
+                   * CocoaPods will be using this to generate tags, and improve search results.
+                   * Try to keep it short, snappy and to the point.
+                   * Finally, don't worry about the indent, CocoaPods strips it!
+                   DESC
+
+  s.homepage     = "https://github.com/mttrb/BeaconOSX"
+
+  s.license      = { :type => 'BSD', :text => <<-LICENSE
+    Copyright (c) 2013, Matthew Robinson All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+    Neither the name of Blended Cocoa nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    LICENSE
+  }
+
+  s.authors          = {
+    "Matthew Robinson" => "matt@zensunni.org",
+    "Falko Richter" => "falko@briefhansa.de",
+    "Robert Carlsen" => "robert@robertcarlsen.net",  # just packaged the podspec
+  }
+
+  s.platform     = :osx, '10.9'
+  s.source       = { :git => "https://github.com/mttrb/BeaconOSX.git", :tag => "0.0.1" }
+  s.source_files  = 'BeaconOSX/BLCBeaconAdvertisementData.{h,m}'
+  s.requires_arc = true
+end

--- a/BeaconOSX.podspec
+++ b/BeaconOSX.podspec
@@ -3,12 +3,9 @@ Pod::Spec.new do |s|
   s.version      = "0.0.1"
   s.summary      = "Use a Bluetooth 4 enabled Mac running Mavericks as an iBeacon."
   s.description  = <<-DESC
-                   A longer description of BeaconOSX in Markdown format.
+                   Use a Bluetooth 4 enabled Mac running Mavericks as an iBeacon.
 
-                   * Think: Why did you write this? What is the focus? What does it do?
-                   * CocoaPods will be using this to generate tags, and improve search results.
-                   * Try to keep it short, snappy and to the point.
-                   * Finally, don't worry about the indent, CocoaPods strips it!
+                   See http://www.blendedcocoa.com/blog/2013/11/02/mavericks-as-an-ibeacon/ for more details.
                    DESC
 
   s.homepage     = "https://github.com/mttrb/BeaconOSX"


### PR DESCRIPTION
This makes it easy to integrate the BLCBeaconAdvertisementData class into a CocoaPods based workspace.
